### PR TITLE
Avoid state usage to populate `Environment`

### DIFF
--- a/src/Control/Monad/Supply.hs
+++ b/src/Control/Monad/Supply.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 -- |
@@ -19,10 +17,6 @@ import Data.Functor.Identity
 
 newtype SupplyT m a = SupplyT { unSupplyT :: StateT Integer m a }
   deriving (Functor, Applicative, Monad, MonadTrans, MonadError e, MonadWriter w, MonadReader r, Alternative, MonadPlus)
-
-instance (MonadState s m) => MonadState s (SupplyT m) where
-  get = SupplyT (lift get)
-  put x = SupplyT (lift (put x))
 
 runSupplyT :: Integer -> SupplyT m a -> m (a, Integer)
 runSupplyT n = flip runStateT n . unSupplyT

--- a/src/Language/PureScript/Environment.hs
+++ b/src/Language/PureScript/Environment.hs
@@ -96,7 +96,7 @@ instance A.ToJSON FunctionalDependency where
 
 -- | The initial environment with no values and only the default javascript types defined
 initEnvironment :: Environment
-initEnvironment = Environment M.empty primTypes M.empty M.empty M.empty primClasses primKinds
+initEnvironment = Environment M.empty allPrimTypes M.empty M.empty M.empty allPrimClasses primKinds
 
 -- | A constructor for TypeClassData that computes which type class arguments are fully determined
 -- and argument covering sets.
@@ -263,7 +263,7 @@ primName = Qualified (Just $ ModuleName [ProperName C.prim]) . ProperName
 
 -- | Construct a 'ProperName' in the @Prim.NAME@ module.
 primSubName :: Text -> Text -> Qualified (ProperName a)
-primSubName sub = 
+primSubName sub =
   Qualified (Just $ ModuleName [ProperName C.prim, ProperName sub]) . ProperName
 
 primKind :: Text -> Kind

--- a/src/Language/PureScript/Interactive/Types.hs
+++ b/src/Language/PureScript/Interactive/Types.hs
@@ -27,7 +27,6 @@ module Language.PureScript.Interactive.Types
 
 import Prelude.Compat
 
-import           Control.Monad.State (evalStateT)
 import qualified Language.PureScript as P
 import qualified Data.Map as M
 import           Language.PureScript.Sugar.Names.Env (nullImports, primExports)
@@ -111,7 +110,7 @@ updateImportExports st@(PSCiState modules lets externs _ _) =
 
   desugarModule :: [P.Module] -> Either P.MultipleErrors (P.Env, [P.Module])
   desugarModule = runExceptT =<< hushWarnings . P.desugarImportsWithEnv (map snd externs)
-  hushWarnings  = flip evalStateT P.initEnvironment . fmap fst . runWriterT
+  hushWarnings  = fmap fst . runWriterT
 
   temporaryName :: P.ModuleName
   temporaryName = P.ModuleName [P.ProperName "$PSCI"]

--- a/src/Language/PureScript/Make.hs
+++ b/src/Language/PureScript/Make.hs
@@ -33,7 +33,6 @@ import           Control.Monad.Supply
 import           Control.Monad.Trans.Class (MonadTrans(..))
 import           Control.Monad.Trans.Control (MonadBaseControl(..))
 import           Control.Monad.Trans.Except
-import           Control.Monad.Trans.State (runStateT)
 import           Control.Monad.Writer.Class (MonadWriter(..))
 import           Data.Aeson (encode, decode)
 import           Data.Either (partitionEithers)
@@ -142,8 +141,8 @@ rebuildModule MakeActions{..} externs m@(Module _ _ moduleName _ _) = do
       withPrim = importPrim m
   lint withPrim
   ((Module ss coms _ elaborated exps, env'), nextVar) <- runSupplyT 0 $ do
-    ([desugared], env') <- runStateT (desugar externs [withPrim]) env
-    runCheck' (emptyCheckState env') $ typeCheckModule desugared
+    [desugared] <- desugar externs [withPrim]
+    runCheck' (emptyCheckState env) $ typeCheckModule desugared
 
   -- desugar case declarations *after* type- and exhaustiveness checking
   -- since pattern guards introduces cases which the exhaustiveness checker

--- a/src/Language/PureScript/Sugar.hs
+++ b/src/Language/PureScript/Sugar.hs
@@ -8,7 +8,6 @@ import Control.Monad
 import Control.Monad.Error.Class (MonadError())
 import Control.Monad.Supply.Class
 import Control.Monad.Writer.Class (MonadWriter())
-import Control.Monad.State (MonadState)
 
 import Data.List (map)
 import Data.Traversable (traverse)
@@ -16,7 +15,6 @@ import Data.Traversable (traverse)
 import Language.PureScript.AST
 import Language.PureScript.Errors
 import Language.PureScript.Externs
-import Language.PureScript.Environment (Environment)
 import Language.PureScript.Sugar.BindingGroups as S
 import Language.PureScript.Sugar.CaseDeclarations as S
 import Language.PureScript.Sugar.DoNotation as S
@@ -55,7 +53,7 @@ import Language.PureScript.Sugar.TypeDeclarations as S
 --  * Group mutually recursive value and data declarations into binding groups.
 --
 desugar
-  :: (MonadSupply m, MonadState Environment m, MonadError MultipleErrors m, MonadWriter MultipleErrors m)
+  :: (MonadSupply m, MonadError MultipleErrors m, MonadWriter MultipleErrors m)
   => [ExternsFile]
   -> [Module]
   -> m [Module]
@@ -73,4 +71,3 @@ desugar externs =
     >=> traverse (deriveInstances externs)
     >=> desugarTypeClasses externs
     >=> traverse createBindingGroupsModule
-

--- a/src/Language/PureScript/Sugar/Names.hs
+++ b/src/Language/PureScript/Sugar/Names.hs
@@ -21,7 +21,6 @@ import Data.Maybe (fromMaybe, mapMaybe)
 import qualified Data.Map as M
 import qualified Data.Set as S
 
-import Language.PureScript.Environment
 import Language.PureScript.AST
 import Language.PureScript.Crash
 import Language.PureScript.Errors
@@ -41,7 +40,7 @@ import Language.PureScript.Types
 --
 desugarImports
   :: forall m
-   . (MonadError MultipleErrors m, MonadState Environment m, MonadWriter MultipleErrors m)
+   . (MonadError MultipleErrors m, MonadWriter MultipleErrors m)
   => [ExternsFile]
   -> [Module]
   -> m [Module]
@@ -50,7 +49,7 @@ desugarImports externs modules =
 
 desugarImportsWithEnv
   :: forall m
-  . (MonadError MultipleErrors m, MonadState Environment m, MonadWriter MultipleErrors m)
+  . (MonadError MultipleErrors m, MonadWriter MultipleErrors m)
   => [ExternsFile]
   -> [Module]
   -> m (Env, [Module])


### PR DESCRIPTION
As per conversation on Slack. :) We can pre-populate `Environment` with everything, as that's the environment of all-possible-things-for-typechecking - it's not used for resolving names and the like.